### PR TITLE
Generics

### DIFF
--- a/src/tagtime/settings/SettingType.java
+++ b/src/tagtime/settings/SettingType.java
@@ -157,7 +157,7 @@ public enum SettingType {
 	 */
 	public final Object defaultValue;
 	
-	SettingType(Class<?> valueClass, Object defaultValue) {
+	<T> SettingType(Class<T> valueClass, T defaultValue) {
 		this.valueClass = valueClass;
 		
 		//defaultValue must be null or an instance of the given type


### PR DESCRIPTION
Java [doesn't seem to let](http://stackoverflow.com/q/4290878/550706) you write `enum SettingType<T>`, but you can still make the constructor take a type parameter and check it there. I left the assert in, but I think this patch makes it unnecessary.
